### PR TITLE
Allow to flush any pending notifications using endBatch

### DIFF
--- a/iota-observable.js
+++ b/iota-observable.js
@@ -198,7 +198,7 @@ Observable = (function() {
     }
   };
 
-  Observable.prototype.endBatch = function() {
+  Observable.prototype.endBatch = function(cancelNotifications) {
     /*
     Ends the batch and carries out the delayed observer notifications.
     
@@ -211,11 +211,13 @@ Observable = (function() {
       _ref = this._invalidationByKeypath;
       for (keypath in _ref) {
         invalidation = _ref[keypath];
-        observers = this._observersByKeypath[keypath];
-        if (observers != null) {
-          for (_i = 0, _len = observers.length; _i < _len; _i++) {
-            observer = observers[_i];
-            observer(keypath, invalidation.oldValue, invalidation.newValue);
+        if (cancelNotifications !== true) {
+          observers = this._observersByKeypath[keypath];
+          if (observers != null) {
+            for (_i = 0, _len = observers.length; _i < _len; _i++) {
+              observer = observers[_i];
+              observer(keypath, invalidation.oldValue, invalidation.newValue);
+            }
           }
         }
         delete this._invalidationByKeypath[keypath];

--- a/src/iota-observable.coffee
+++ b/src/iota-observable.coffee
@@ -156,7 +156,7 @@ class Observable
       @_inBatch = true
       true
   
-  endBatch: ->
+  endBatch: (cancelNotifications) ->
     ###
     Ends the batch and carries out the delayed observer notifications.
     
@@ -167,11 +167,12 @@ class Observable
       
       # Call observers of keypath. Make for each keypath-observer combination exactly one call.
       for keypath, invalidation of @_invalidationByKeypath
-        observers = @_observersByKeypath[keypath]
-        if observers?
-          for observer in observers
-            observer(keypath, invalidation.oldValue, invalidation.newValue)
-        
+        if cancelNotifications != true
+          observers = @_observersByKeypath[keypath]
+          if observers?
+            for observer in observers
+              observer(keypath, invalidation.oldValue, invalidation.newValue)
+
         # Remove invalidation
         delete @_invalidationByKeypath[keypath]
       true

--- a/test/iota-observable-test.coffee
+++ b/test/iota-observable-test.coffee
@@ -137,6 +137,18 @@ createTests = (description, createObservable) ->
       callback.should.have.been.calledOnce
       
       
+
+    it "should not call observers for each invalidated property if ending batch with flag set", ->
+      callback = sinon.spy()
+      o.on "foo", callback
+
+      o.beginBatch()
+      o.set("foo", 3)
+      o.set("foo", 3)
+      o.endBatch(true)
+
+      callback.should.not.have.been.calledOnce
+
     it "should call registered observers of a computed property when setting a dependency of the computed property via set", ->
       o.get("x").should.equal 72
       


### PR DESCRIPTION
Useful if the observed object is updated / reset and you don't want observers notified
